### PR TITLE
Failed Tests in Frontend Stops Pushing to Remote

### DIFF
--- a/paracord-ui/package.json
+++ b/paracord-ui/package.json
@@ -27,7 +27,10 @@
     "rules": {
       "semi": "error",
       "space-before-function-paren": ["error", "never"],
-      "max-len": ["error", { "code": 120 }]
+      "max-len": ["error", { "code": 120 }],
+      "indent": ["error", 3],
+      "react/jsx-indent": ["error", 3],
+      "react/jsx-indent-props": ["error", 3]
     }
   },
   "browserslist": {

--- a/paracord-ui/package.json
+++ b/paracord-ui/package.json
@@ -12,7 +12,7 @@
     "tailwind:css": "npx tailwind build src/css/App.css -o src/generated/tailwind.css",
     "start": "yarn tailwind:css && react-scripts start",
     "build": "react-scripts build",
-    "test": "cross-env CI=true && react-scripts test --watchAll=false",
+    "test": "cross-env CI=true && react-scripts test --watchAll=false --bail",
     "test-watch": "cross-env CI=true && react-scripts test",
     "lint": "eslint --ignore-path .gitignore .",
     "lint-fix": "eslint --fix --ignore-path .gitignore .",

--- a/paracord-ui/src/App.js
+++ b/paracord-ui/src/App.js
@@ -1,26 +1,27 @@
+
 import React from 'react'
 import logo from './logo.svg'
 import './generated/tailwind.css'
 
 function App() {
-  return (
-    <div className='App'>
-      <header className='App-header'>
-        <img src={logo} className='App-logo' alt='logo' />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className='App-link'
-          href='https://reactjs.org'
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  )
+   return (
+      <div className='App'>
+         <header className='App-header'>
+            <img src={logo} className='App-logo' alt='logo' />
+            <p>
+               Edit <code>src/App.js</code> and save to reload.
+            </p>
+            <a
+               className='App-link'
+               href='https://reactjs.org'
+               target='_blank'
+               rel='noopener noreferrer'
+            >
+               Learn React
+            </a>
+         </header>
+      </div>
+   )
 }
 
 export default App

--- a/paracord-ui/src/__tests__/App.test.js
+++ b/paracord-ui/src/__tests__/App.test.js
@@ -4,7 +4,6 @@ import App from '../App'
 
 it('renders without crashing', () => {
    const div = document.createElement('div')
-   expect(true).toBe(false)
    ReactDOM.render(<App />, div)
    ReactDOM.unmountComponentAtNode(div)
 })

--- a/paracord-ui/src/__tests__/App.test.js
+++ b/paracord-ui/src/__tests__/App.test.js
@@ -3,7 +3,8 @@ import ReactDOM from 'react-dom'
 import App from '../App'
 
 it('renders without crashing', () => {
-  const div = document.createElement('div')
-  ReactDOM.render(<App />, div)
-  ReactDOM.unmountComponentAtNode(div)
+   const div = document.createElement('div')
+   expect(true).toBe(false)
+   ReactDOM.render(<App />, div)
+   ReactDOM.unmountComponentAtNode(div)
 })

--- a/paracord-ui/tailwind.config.js
+++ b/paracord-ui/tailwind.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  theme: {
-    extend: {}
-  },
-  variants: {},
-  plugins: []
+   theme: {
+      extend: {}
+   },
+   variants: {},
+   plugins: []
 }


### PR DESCRIPTION
This PR:

* Stops the push to the repo if one of the Jest tests fail, because it wasn't doing that before
* Adds a couple more linting rules for indentation in the frontend files

Basically, the Jest process was saying that it was successful even on a test failure, so Husky thought everything was all good no matter what.

Now, when we run the `yarn test` command, we pass a `--bail` argument to make Jest puke as soon as a test fails, stopping the push from going through.

[Jest CLI Options](https://jestjs.io/docs/en/cli#bail)