### PR TITLE
Adding a start.cmd file for easy run in parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 A ReactJS front-end and Java JAX-RS REST api web project that will hold random useful tools for us and friends with various scopes.
 
 # Run
-Run the `start.cmd` command
+|CLI|Command|
+|---|-------|
+|Powershell| `.\start.cmd`|
+|Git Bash on Windows|`start start.cmd`|
+|Windows CMD|`start.cmd`|
+
 Or
+
 Go into each project and run the commands

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Paracord
 A ReactJS front-end and Java JAX-RS REST api web project that will hold random useful tools for us and friends with various scopes.
+
+# Run
+Run the `start.cmd` command
+Or
+Go into each project and run the commands

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -76,6 +76,8 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.1.1</version>
         <configuration>
+          <finalName>paracord-server-executable</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>

--- a/start.cmd
+++ b/start.cmd
@@ -1,0 +1,40 @@
+@echo off
+
+echo ***************************************************
+echo **            Building REST server               **
+echo ***************************************************
+cd server
+call mvn clean package || goto :error
+
+
+echo ***************************************************
+echo **             Starting REST server              **
+echo ***************************************************
+start cmd /k "java -jar target/paracord-server-executable.jar && exit"
+timeout /t 5 /nobreak > NUL
+echo =========S T A R T E D=========
+cd ..
+
+echo ***************************************************
+echo **             Building React App                **
+echo ***************************************************
+echo Pulling React dependencies
+cd paracord-ui
+echo Pulling React dependencies
+call yarn || goto :error
+
+echo ***************************************************
+echo **             Starting React App                **
+echo ***************************************************
+start cmd /k "yarn start && exit"
+timeout /t 5 /nobreak > NUL
+echo =========S T A R T E D=========
+cd ..
+
+set /p DUMMY=The applications have started! Hit ENTER to close...
+goto :EOF
+
+:error
+echo One of the build steps has failed.
+set /p DUMMY=Hit ENTER to close...
+exit


### PR DESCRIPTION
In this PR:
- Updated server pom to rename the executable jar file so it is generic.
- Added a start.cmd file that should start both react and rest applications.