### PR TITLE
Upgrades `eslint-utils`

### DIFF
--- a/paracord-ui/package.json
+++ b/paracord-ui/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-node": "~9.1.0",
     "eslint-plugin-promise": "~4.1.1",
     "eslint-plugin-react": "~7.13.0",
-    "eslint-plugin-standard": "~4.0.0"
+    "eslint-plugin-standard": "~4.0.0",
+    "eslint-utils": "~1.4.2"
   }
 }

--- a/paracord-ui/yarn.lock
+++ b/paracord-ui/yarn.lock
@@ -3698,6 +3698,13 @@ eslint-utils@^1.3.0, eslint-utils@^1.3.1:
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
   integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
 
+eslint-utils@~1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"


### PR DESCRIPTION
## Proposed Changes

  - Explicitly installs `eslint-utils@^1.4.1` to fix security alert
